### PR TITLE
Shallow clone Ansible repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - checkout
       - run:
           command: |
-            git clone -b slxos_modules https://github.com/StackStorm/ansible
+            git clone --depth 1 -b slxos_modules https://github.com/StackStorm/ansible
             cd ansible
             pip install -r requirements.txt
             . ./hacking/env-setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,8 @@ jobs:
       - checkout
       - run:
           command: |
-            git clone https://github.com/StackStorm/ansible
+            git clone -b slxos_modules https://github.com/StackStorm/ansible
             cd ansible
-            git checkout slxos_modules
             pip install -r requirements.txt
             . ./hacking/env-setup
             pip install ansible-lint


### PR DESCRIPTION
Switching to a shallow clone of Ansible repo. Much smaller & faster download.

Unscientific testing:

```shell
lindsaysmacbook:~ lhill$ time git clone -b slxos_modules https://github.com/StackStorm/ansible
Cloning into 'ansible'...
remote: Counting objects: 302876, done.
remote: Compressing objects: 100% (12/12), done.
remote: Total 302876 (delta 5), reused 0 (delta 0), pack-reused 302864
Receiving objects: 100% (302876/302876), 108.63 MiB | 4.85 MiB/s, done.
Resolving deltas: 100% (191732/191732), done.
Checking out files: 100% (8668/8668), done.

real	0m40.501s
user	0m20.291s
sys	0m11.560s
lindsaysmacbook:~ lhill$ time git clone --depth 1 -b slxos_modules https://github.com/StackStorm/ansible ansible_shallow
Cloning into 'ansible_shallow'...
remote: Counting objects: 9729, done.
remote: Compressing objects: 100% (6699/6699), done.
remote: Total 9729 (delta 1872), reused 7021 (delta 1535), pack-reused 0
Receiving objects: 100% (9729/9729), 12.03 MiB | 3.99 MiB/s, done.
Resolving deltas: 100% (1872/1872), done.
Checking out files: 100% (8668/8668), done.

real	0m16.145s
user	0m1.841s
sys	0m3.436s
lindsaysmacbook:Downloads lhill$
```