### PR TITLE
More complex demo playbook for configuring multiple elements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,4 +13,4 @@ jobs:
             . ./hacking/env-setup
             pip install ansible-lint
             cd ../slxos/playbooks
-            ansible-lint -v *.yaml
+            ansible-lint -v *.yaml */*.yml

--- a/slxos/playbooks/demo/README.md
+++ b/slxos/playbooks/demo/README.md
@@ -1,0 +1,25 @@
+## Demo Playbooks
+
+This is a more complex set of plays, designed to configure multiple elements on multiple devices.
+
+For a simple leaf-spine network of two leafs and one spine, it will do the following:
+
+* Set device hostnames
+* Set NTP and timezone
+* Configure LLDP to advertise the management IP
+* Enable the inter-switch links, and assign descriptions and IP Addresses
+* Configure a Port-Channel on each Leaf switch
+* Create VLANs and assign ports
+* Configure BGP peering between devices.
+
+This is all configured using group\_vars and host\_vars.
+
+To run this playbook, configure your hosts, group\_vars and host\_vars as required, then run
+`ansible-playbook site.yml`
+
+There is also a set of "Check" plays that will:
+* Check that NTP is synchronized
+* Check that LLDP shows devices cabled as expected
+* Grab the `show ip bgp summary` output from each device, and publish it.
+
+To run this, use `ansible-playbook check.yml`. Note that it uses values from host\_vars to specify which LLDP neighbors to look for.

--- a/slxos/playbooks/demo/ansible.cfg
+++ b/slxos/playbooks/demo/ansible.cfg
@@ -1,0 +1,7 @@
+[defaults]
+ansible_python_interpreter=~/ansible/venv/bin/python
+host_key_checking = False
+inventory = ~/playbooks/demo/hosts
+# ask_pass = True
+#log_path=~/ansible.log
+#debug = True

--- a/slxos/playbooks/demo/check.yml
+++ b/slxos/playbooks/demo/check.yml
@@ -1,0 +1,10 @@
+---
+
+- hosts: slx-all
+
+  gather_facts: 'False'
+
+  roles:
+    - ntp_check
+    - lldp_check
+    - bgp_check

--- a/slxos/playbooks/demo/group_vars/all.yml
+++ b/slxos/playbooks/demo/group_vars/all.yml
@@ -1,0 +1,9 @@
+---
+ansible_user: admin
+ansible_ssh_pass: password
+
+ntp:
+  - '172.16.10.2'
+  - '172.16.10.5'
+
+timezone: Europe/Warsaw

--- a/slxos/playbooks/demo/host_vars/DC2LEAF1.yml
+++ b/slxos/playbooks/demo/host_vars/DC2LEAF1.yml
@@ -1,0 +1,30 @@
+---
+
+neighbors:
+  'Ethernet 0/49':
+    host: 'DC2SPINE1'
+    port: 'Ethernet 0/25'
+
+port_group_mapping:
+  - group: 200
+    members:
+      - Ethernet 0/6
+      - Ethernet 0/7
+
+vlans:
+  - vlan_id: 200
+    interfaces:
+      - Port-channel 200
+
+bgp_fabric:
+  asn: 65300
+  # router_id: 10.255.0.3
+  neighbor:
+    - {address: 10.254.254.5, remote_as: 65500}
+  networks:
+
+interfaces:
+  'Ethernet 0/49':
+    enabled: True
+    description: "DC2SPINE1 Eth 0/25"
+    ip: 10.254.254.4/31

--- a/slxos/playbooks/demo/host_vars/DC2LEAF2.yml
+++ b/slxos/playbooks/demo/host_vars/DC2LEAF2.yml
@@ -1,0 +1,30 @@
+---
+
+neighbors:
+  'Ethernet 0/49':
+    host: 'DC2SPINE1'
+    port: 'Ethernet 0/27'
+
+port_group_mapping:
+  - group: 200
+    members:
+      - Ethernet 0/6
+      - Ethernet 0/7
+
+vlans:
+  - vlan_id: 200
+    interfaces:
+      - Port-channel 200
+
+bgp_fabric:
+  asn: 65301
+  # router_id: 10.255.0.3
+  neighbor:
+    - {address: 10.254.254.3, remote_as: 65500}
+  networks:
+
+interfaces:
+  'Ethernet 0/49':
+    enabled: True
+    description: "DC2SPINE1 Eth 0/27"
+    ip: 10.254.254.2/31

--- a/slxos/playbooks/demo/host_vars/DC2SPINE1.yml
+++ b/slxos/playbooks/demo/host_vars/DC2SPINE1.yml
@@ -1,0 +1,27 @@
+---
+
+neighbors:
+  'Ethernet 0/25':
+    host: 'DC2LEAF1'
+    port: 'Ethernet 0/49'
+  'Ethernet 0/27':
+    host: 'DC2LEAF2'
+    port: 'Ethernet 0/49'
+
+bgp_fabric:
+  asn: 65500
+  # router_id: 10.255.0.3
+  neighbor:
+    - {address: 10.254.254.2, remote_as: 65301}
+    - {address: 10.254.254.4, remote_as: 65300}
+  networks:
+
+interfaces:
+  'Ethernet 0/25':
+    enabled: True
+    description: "DC2LEAF1 Eth 0/49"
+    ip: 10.254.254.5/31
+  'Ethernet 0/27':
+    enabled: True
+    description: "DC2LEAF2 Eth 0/49"
+    ip: 10.254.254.3/31

--- a/slxos/playbooks/demo/hosts
+++ b/slxos/playbooks/demo/hosts
@@ -1,0 +1,10 @@
+[slx-leaf]
+DC2LEAF1 ansible_network_os=slxos ansible_connection=network_cli
+DC2LEAF2 ansible_network_os=slxos ansible_connection=network_cli
+
+[slx-spine]
+DC2SPINE1 ansible_network_os=slxos ansible_connection=network_cli
+
+[slx-all:children]
+slx-leaf
+slx-spine

--- a/slxos/playbooks/demo/roles/bgp_check/tasks/main.yml
+++ b/slxos/playbooks/demo/roles/bgp_check/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Get BGP status
+  slxos_command:
+    commands: "show ip bgp summary"
+  register: bgp_summary
+
+- name: Display BGP status
+  debug:
+    var: bgp_summary.stdout_lines[0]

--- a/slxos/playbooks/demo/roles/hostname/tasks/main.yml
+++ b/slxos/playbooks/demo/roles/hostname/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+
+- name: Set device hostname
+  slxos_config:
+    lines: 'switch-attributes host-name {{ inventory_hostname }}'

--- a/slxos/playbooks/demo/roles/interfaces/tasks/main.yml
+++ b/slxos/playbooks/demo/roles/interfaces/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Interface state and description
+  slxos_interface:
+    name: "{{ item.key }}"
+    enabled: "{{ item.value.enabled }}"
+    description: "{{ item.value.description }}"
+  with_dict: "{{ interfaces }}"
+
+- name: Interface IP Address
+  slxos_config:
+    parents: interface {{ item.key }}
+    lines: ip address {{ item.value.ip }}
+  with_dict: "{{ interfaces }}"

--- a/slxos/playbooks/demo/roles/lldp/tasks/main.yml
+++ b/slxos/playbooks/demo/roles/lldp/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Configure LLDP to advertise Management IP
+  slxos_config:
+    lines: advertise optional-tlv management-address
+    parents: protocol lldp

--- a/slxos/playbooks/demo/roles/lldp_check/tasks/main.yml
+++ b/slxos/playbooks/demo/roles/lldp_check/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Check LLDP neighbors
+  slxos_interface:
+    name: "{{ item.key }}"
+    neighbors:
+      - port: "{{ item.value.port }}"
+        host: "{{ item.value.host }}"
+  with_dict: "{{ neighbors }}"

--- a/slxos/playbooks/demo/roles/ntp/tasks/main.yml
+++ b/slxos/playbooks/demo/roles/ntp/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Set NTP and Timezone
+  slxos_config:
+    lines:
+      - ntp server {{ item }} use-vrf mgmt-vrf
+      - clock timezone {{ timezone }}
+  with_items: '{{ ntp }}'

--- a/slxos/playbooks/demo/roles/ntp_check/tasks/main.yml
+++ b/slxos/playbooks/demo/roles/ntp_check/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Check ntp status
+  slxos_command:
+    commands: "show ntp status"
+    wait_for: result[0] contains 172
+    retries: 1

--- a/slxos/playbooks/demo/roles/port_channels/tasks/main.yml
+++ b/slxos/playbooks/demo/roles/port_channels/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+
+- name: "Configure LAGs"
+  slxos_linkagg:
+    group: "{{ item['group'] }}"
+    mode: active
+    members: "{{ item['members']|join(',') }}"
+  with_items: "{{ port_group_mapping }}"
+  when: port_group_mapping is defined

--- a/slxos/playbooks/demo/roles/routing/tasks/main.yml
+++ b/slxos/playbooks/demo/roles/routing/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+
+- name: BGP Local AS
+  slxos_config:
+    #src: templates/routing.j2
+    parents: router bgp
+    lines: local-as {{ bgp_fabric.asn }}
+
+- name: BGP Peers
+  slxos_config:
+    parents: router bgp
+    lines: neighbor {{ item.address }} remote-as {{ item.remote_as }}
+  with_items: "{{ bgp_fabric.neighbor }}"
+
+- name: BGP Networks
+  slxos_config:
+    parents: router bgp
+    lines: network {{ item }}
+  with_items: "{{ bgp_fabric.network }}"
+  when: bgp_fabric.network is defined

--- a/slxos/playbooks/demo/roles/vlans/tasks/main.yml
+++ b/slxos/playbooks/demo/roles/vlans/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+
+- name: "Configure VLANs"
+  slxos_vlan:
+    vlan_id: "{{ item['vlan_id'] }}"
+    interfaces: "{{ item['interfaces']|join(',') }}"
+  with_items: "{{ vlans }}"
+  when: vlans is defined

--- a/slxos/playbooks/demo/site.yml
+++ b/slxos/playbooks/demo/site.yml
@@ -1,0 +1,16 @@
+---
+
+- hosts: slx-all
+
+  gather_facts: 'False'
+
+  roles:
+    - hostname
+    - ntp
+    - lldp
+    - role: interfaces
+      when: interfaces is defined
+    - port_channels
+    - vlans
+    - role: routing
+      when: bgp_fabric is defined


### PR DESCRIPTION
More complex set of demo playbooks/roles that configure multiple elements on a multi-node network.

Configure interface state, LLDP, IP addresses, BGP, VLANs, Port Channels. All site-specific info is taken from `host_vars` and `group_vars`, rather than defined in the playbooks.