### PR TITLE
Updated READMEs to reflect upstream module merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ SLX modules are in active development. Currently available modules are:
 * slxos\_l2\_interface – Manage L2 Interfaces
 * slxos\_l3\_interface – Manage L3 Interfaces
 
-These modules are in active development. Some have been merged with upstream Ansible, others have open Pull Requests. Check out the [README](./slxos/README.md) in the [slxos](./slxos) folder for more details about what the modules can do, how to install them, and example playbooks.
+These modules are in active development. They have been merged with Ansible's pre-release branch, will be included in Ansible's next GA version -2.6, ETA late June 2018. 
+You can get access to these now - check the [README](./slxos/README.md) in the [slxos](./slxos) folder for more details about what the modules can do, how to install them, and example playbooks.
 
 ## Ironware (MLXe)
 
@@ -42,7 +43,7 @@ Click the links above to see docs on how to use those modules.
 
 ## EXOS
 
-[Rafael Vencioneck](https://github.com/rdvencioneck) has begun work on EXOS modules. The first of these has been merged into the Ansible devel branch, and will go GA in version 2.6 (ETA July 2018). 
+[Rafael Vencioneck](https://github.com/rdvencioneck) has begun work on EXOS modules. The first of these has been merged into the Ansible devel branch, and will go GA in version 2.6 (ETA June 2018). 
 
 Available modules:
 

--- a/slxos/README.md
+++ b/slxos/README.md
@@ -2,11 +2,11 @@
 
 This document explains how to use Ansible with Extreme SLX devices.
 
-These modules are currently in development, and have not yet been merged with upstream Ansible. As such there are additional steps required to set up a development environment tracking the latest modules. 
+These modules have now yet been merged with upstream Ansible. They are currently in the "devel" branch. They will be included in 2.6 GA, which is expected to ship in late June 2018. Until then, there are some additional steps required to use these modules. 
 
 These instructions will show you how to set up a dev environment in your home directory, and provides example playbooks for using each of the available modules.
 
-These instructions will be updated when the modules are merged upstream.
+These instructions will be updated when Ansible 2.6 goes GA.
 
 ## Sections:
 
@@ -26,16 +26,16 @@ All playbooks shown in this README are also available in the [playbooks](./playb
 
 ## System Setup
 
-Install Ansible in your home directory, using our latest development branch:
+Install Ansible in your home directory, using the latest development branch:
 
-> NB in future you will be able to install Ansible using [normal Ansible installation procedures](https://docs.ansible.com/ansible/intro_installation.html). Our modules have not yet been merged upstream.
+> NB When Ansible 2.6 ships, you will be able to install Ansible using [normal Ansible installation procedures](https://docs.ansible.com/ansible/intro_installation.html).
 
 ### First time setup:
 
 #### Ansible Install
 
 ```shell
-git clone -b slxos_modules https://github.com/StackStorm/ansible
+git clone https://github.com/ansible/ansible.git --recursive
 cd ansible
 virtualenv venv
 .  ./venv/bin/activate

--- a/slxos/README.md
+++ b/slxos/README.md
@@ -24,6 +24,8 @@ These instructions will be updated when Ansible 2.6 goes GA.
 
 All playbooks shown in this README are also available in the [playbooks](./playbooks) directory.
 
+SLX Module documentation is in the [Ansible docs here](http://docs.ansible.com/ansible/devel/modules/list_of_network_modules.html#slxos)
+
 ## System Setup
 
 Install Ansible in your home directory, using the latest development branch:


### PR DESCRIPTION
Minor update reflecting that modules have now been merged upstream, and users can just pull directly from ansible/ansible, rather than our fork.